### PR TITLE
Fix local files during format generation

### DIFF
--- a/src/bundles.js
+++ b/src/bundles.js
@@ -353,11 +353,23 @@ export class BundleManager {
         // Scan main source
         scanSource(source);
 
-        // Scan additional files (for multi-file documents)
-        const texFiles = Object.entries(additionalFiles).filter(([f]) => f.endsWith('.tex'));
-        if (texFiles.length > 0) {
+        // Scan additional LaTeX sources referenced by the workspace, not just
+        // .tex files. Local .sty/.cls files often declare package dependencies
+        // that should be resolved before the TeX run starts.
+        const latexLikeFiles = Object.entries(additionalFiles).filter(([f]) =>
+            /\.(tex|sty|cls|clo|def|cfg)$/i.test(f)
+        );
+        const localPackageNames = new Set(
+            latexLikeFiles
+                .map(([f]) => {
+                    const base = f.split('/').pop() || f;
+                    return base.replace(/\.(tex|sty|cls|clo|def|cfg)$/i, '');
+                })
+                .filter(Boolean)
+        );
+        if (latexLikeFiles.length > 0) {
             const decoder = new TextDecoder(); // Reuse for all files
-            for (const [, content] of texFiles) {
+            for (const [, content] of latexLikeFiles) {
                 const text = typeof content === 'string' ? content : decoder.decode(content);
                 scanSource(text);
             }
@@ -396,6 +408,10 @@ export class BundleManager {
         const additionalBundles = new Set();
 
         for (const pkg of expanded) {
+            // Local workspace files should satisfy their own package/class
+            // references; prefetching them from CTAN creates bogus 404s.
+            if (localPackageNames.has(pkg)) continue;
+
             const bundleName = this.packageMap?.[pkg];
             if (bundleName && this.bundleExists(bundleName)) {
                 if (directBundles.has(bundleName)) {

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -926,7 +926,10 @@ export class SiglumCompiler {
                         // Do this in background to not block the compile result
                         // Skip for xelatex - XeTeX can't dump formats with native fonts
                         if (!cachedFormat && preamble && engine !== 'xelatex') {
-                            this.generateFormat(source, { engine }).then(async () => {
+                            this.generateFormat(source, {
+                                engine,
+                                additionalFiles: options.additionalFiles || {},
+                            }).then(async () => {
                                 // Populate memory cache from the newly generated format
                                 await ensureFmtCacheMount();
                                 const data = await fileSystem.readBinary('/' + getFmtPath(fmtKey)).catch(() => null);
@@ -982,11 +985,12 @@ export class SiglumCompiler {
     /**
      * Pre-generate a format file for faster subsequent compilations.
      * @param {string} source - LaTeX source with preamble to cache
-     * @param {{engine?: string}} [options] - Options
+     * @param {{engine?: string, additionalFiles?: Object<string, string|Uint8Array>}} [options] - Options
      * @returns {Promise<Uint8Array|null>} Format data or null if not supported
      */
     async generateFormat(source, options = {}) {
         const engine = options.engine || 'pdflatex';
+        const additionalFiles = options.additionalFiles || {};
 
         // XeTeX can't dump formats with native fonts (fontspec)
         if (engine === 'xelatex') {
@@ -1022,7 +1026,7 @@ export class SiglumCompiler {
         // Get dependency bundles from prescan (e.g., utils for environ)
         let depBundles = [];
         if (this.enableCtan) {
-            const { additionalBundles } = this.bundleManager.prescanForCtanPackages(source, engine, {});
+            const { additionalBundles } = this.bundleManager.prescanForCtanPackages(source, engine, additionalFiles);
             if (additionalBundles && additionalBundles.length > 0) {
                 depBundles = additionalBundles;
             }
@@ -1033,6 +1037,12 @@ export class SiglumCompiler {
 
         // Get CTAN files from memory cache
         const ctanFiles = this.ctanFetcher.getCachedFiles();
+        for (const [filename, content] of Object.entries(additionalFiles)) {
+            const data = typeof content === 'string'
+                ? new TextEncoder().encode(content)
+                : content;
+            ctanFiles['/' + filename] = data;
+        }
 
         this._log('Generating format file...');
         this.onProgress('format', 'Generating format...');


### PR DESCRIPTION
## Summary
- pass `additionalFiles` into format generation
- scan local LaTeX-related files like `.sty` and `.cls` during prescan
- avoid CTAN prefetches for packages that are already provided by local workspace files

## Why
Multi-file documents can include local style/class files. Before this change, format generation and CTAN prescan could treat those as missing external packages, causing false 404s and retry loops.

## Test plan
- compile a document that includes a local `.sty` file
- verify the local package is used without a CTAN fetch
- run `npm run build:types`